### PR TITLE
Update to align with Unimod a little better

### DIFF
--- a/specification/reference_data/reference_molecules.json
+++ b/specification/reference_data/reference_molecules.json
@@ -114,24 +114,34 @@
     "molecule_type": "reporter",
     "ion_mz": 135.1516
   },
-  "TMT0nterm": {
+  "TMTzero": {
     "label_type": "TMTzero",
     "molecule_type": "reporter+balance",
+    "neutral_mass": 224.152478,
     "ion_mz": 225.15975447
   },
-  "TMT2nterm": {
+  "TMTpro_zero": {
+    "label_type": "TMTpro_zero",
+    "molecule_type": "reporter+balance",
+    "neutral_mass": 295.189592,
+    "ion_mz": 296.1968685
+  },
+  "TMT2plex": {
     "label_type": "TMT2plex",
     "molecule_type": "reporter+balance",
+    "neutral_mass": 225.155833,
     "ion_mz": 226.16310947
   },
-  "TMT6nterm": {
+  "TMT6plex": {
     "label_type": "TMT6plex",
     "molecule_type": "reporter+balance",
+    "neutral_mass": 229.162932,
     "ion_mz": 230.17020847
   },
-  "TMTPROnterm": {
-    "label_type": "TMTPro",
+  "TMTpro": {
+    "label_type": "TMTpro",
     "molecule_type": "reporter+balance",
+    "neutral_mass": 304.207146,
     "ion_mz": 305.21442247
   },
   "iTRAQ113": {
@@ -174,14 +184,16 @@
     "molecule_type": "reporter",
     "ion_mz": 121.122
   },
-  "iTRAQ4nterm": {
+  "iTRAQ4plex": {
     "label_type": "iTRAQ4plex",
     "molecule_type": "reporter+balance",
+    "neutral_mass": 144.102063,
     "ion_mz": 145.10933947
   },
-  "iTRAQ8nterm": {
+  "iTRAQ8plex": {
     "label_type": "iTRAQ8plex",
     "molecule_type": "reporter+balance",
+    "neutral_mass": 304.205360,
     "ion_mz": 305.21263647
   },
   "TMT126-ETD": {


### PR DESCRIPTION
Add TMTpro_zero and adjust names to match Unimod (mostly. except change Unimod "TMT" to "TMTzero" as seemingly more pleasant) and add neutral_masses to facilitate neutral loss calculations.
